### PR TITLE
Version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.0.0
+
+Improved terminal instance tracking. Previously, the system relied on random strings and filtering DOM nodes to track which instance was the current one. Not only was this rather unsafe, it also introduced a risk of collisions.
+
+This version removes the above behaviour and replaces it with the React refs API. As such, this module now requires React 16.3 or above. This is enforced by adding `react` and `react-dom` version 16.3.0 and up as peerDependencies.
+
 # 1.7.3
 
 Enabled module transpilation to widen the support amongst Node versions for distributed code. This allows the module to work even when Babel is not being used at the top level.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
 # 2.0.0
 
+### Breaking changes
+
 Improved terminal instance tracking. Previously, the system relied on random strings and filtering DOM nodes to track which instance was the current one. Not only was this rather unsafe, it also introduced a risk of collisions.
 
-This version removes the above behaviour and replaces it with the React refs API. As such, this module now requires React 16.3 or above. This is enforced by adding `react` and `react-dom` version 16.3.0 and up as peerDependencies.
+This version removes the above behaviour and replaces it with the React refs API. As such, **this module now requires React 16.3 or above.** This is enforced by adding `react` and `react-dom` version 16.3.0 and up as peerDependencies.
+
+In correlation with the introduction of refs, a new system will replace the similarly old and unsustainable `manualPushToStdout()` API. Documentation for the new system has been added to the README, while the old method docs have been moved to [LEGACY.md](LEGACY.md).
+
+The above document also contains more information on the deprecation of `manualPushToStdout()`. The short version is that **manualPushToStdout is from this version onwards considered a deprecated legacy API that will eventually be removed.** A gradual deprecation scheme starts from this version with a warning emitted to the console when the function is used. See the legacy document for more information.
+
+### Other changes
+
+Fixed a multitude of bugs related to terminal history scrolling. In the past, items would get displayed twice when suddenly changing scrolling direction mid-travel. The terminal would also display out-of-range items (Manifesting as `undefined` entries in history). These bugs have now been fixed and the system has been made more robust overall.
+
+Added the ability to disable input to the terminal during command processing. If enabled via the `disableOnProcess` prop, the terminal will be disabled while a command processing session is active.
+
+Added the ability to supply custom font families to the terminal content and input via the `contentFontFamily` and `inputFontFamily` props.
 
 # 1.7.3
 

--- a/LEGACY.md
+++ b/LEGACY.md
@@ -1,0 +1,39 @@
+## Why is manualPushToStdout deprecated?
+
+Put simply, it was a badly engineered way to add content to the terminal asynchronously. As a method of adding content to a terminal, it was unsustainable, quirky and broke the component-based structure as it was called on an instance rather than on a component. It disabled large parts of the component's operation as well, hampering a very valid use case.
+
+## What is going to happen to it?
+
+Don't worry, the function is still available for now. This is the current roadmap for gradually phasing out the manualPushToStdout function.
+
+- Version 2.0.0: Terminal.manualPushToStdout() will emit a deprecation warning upon use.
+- Future 2.x.x release 1: Terminal.manualPushToStdout() will emit a deprecation error upon use and not push output to the terminal.
+- Future 2.x.x release 2: Terminal.manualPushToStdout() is removed completely.
+
+## What should I do?
+
+You should migrate to the new method of asynchronous content pushing as soon as possible, since the old method may stop working at any time.
+
+A much better way of asynchronously pushing content to the terminal was added in version 2.0.0, one that uses the React refs API and hooks into the normal terminal lifecycle. It allows you to take full advantage of the terminal functionality and still push content to it asynchronously. It's the old system with no compromises. What's not to like about that?
+
+You can find out how to use the new method and associated documentation in the [Async output](README.md#async-output) section of the README.
+
+## Legacy documentation
+
+The documentation for the manualPushToStdout() function can be found below until the method is removed in an eventual future release.
+
+### static manualPushToStdout (message, dangerMode, contentElement, inputElement, inputAreaElement)
+
+This is a static function you can call on an instance of react-console-emulator. It allows you to manually push output to the terminal. This may be useful if you have async code that needs to push output even after the function has returned.
+
+**Warning:** Using this function is not optimal and should be avoided if possible. If used, it is additionally recommended to set the **noAutomaticStdout** property to disable automatic output and command history (The latter of which will not work in this case).
+
+**Parameter reference**
+
+| Parameter | Description | Type |
+| --------- | ----------- | ---- |
+| message | The message to push to the console. Can be HTML if **dangerMode** is set to true. | String |
+| dangerMode | If set, set message content with innerHTML as opposed to innerText. It is highly recommended to XSS-proof the message if this setting is being used. | Boolean |
+| contentElement | The content element to push output to. Uses the first element with the name **react-console-emulator__content** on the page if omitted. | HTMLElement |
+| inputElement | The input element to clear after a command. Uses the first element with the name **react-console-emulator__input** on the page if omitted. | HTMLElement |
+| inputAreaElement | The input area element to re-position after a command. Uses the first element with the name **react-console-emulator__inputArea** on the page if omitted. | HTMLElement |

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The function of the `wait` command hooks into the terminal lifecycle (See [Termi
 
 The only notable caveat of this method is the breaking of component encapsulation. This is the trade-off for being able to push content on demand.
 
-**Note:** Assigning a ref to the terminal component **exposes all of its functions and properties**. As such, you should take adequate measures against this being abused by end users and treat an exposed terminal with caution in genreral.
+**Note:** Assigning a ref to the terminal component **exposes all of its functions and properties**. As such, you should take adequate measures against this being abused by end users and treat an exposed terminal with caution in general.
 
 ### Terminal lifecycle
 
@@ -176,9 +176,9 @@ Per standard, the terminal operates in the following way when a command is enter
 
 - A key event triggers the [handleInput](src/components/Terminal.jsx#L242) function.
 - The [handleInput](src/components/Terminal.jsx#L242) function behaves as follows:
-  - If the up or down arrows were pressed, [scrollHistory](src/components/Terminal.jsx#L200) is called with either `up` or `down` as a parameter, corresponding to the arrow key that was pressed.
+  - If the either up or down arrow was pressed, [scrollHistory](src/components/Terminal.jsx#L200) is called with either `up` or `down` as a parameter, corresponding to the arrow key that was pressed.
   - If the Enter key was pressed, [processCommand](src/components/Terminal.jsx#L163) is called.
-- Following the Enter path, if automatic stdout isn't disabled via the `noAutomaticStdout` prop, [pushToStdout](src/components/Terminal.jsx#L128) is called for the first time. This echoes the command that was entered into the terminal verbatim to mimic a UNIX terminal.
+- Following the Enter path, if automatic output isn't disabled via the `noAutomaticStdout` prop, [pushToStdout](src/components/Terminal.jsx#L128) is called for the first time. This echoes the command that was entered into the terminal verbatim to mimic a UNIX terminal.
   - If history isn't disabled via the `noHistory` prop, the entered command is also stored in the history at this stage.
 - If the input isn't empty, command processing begins.
   - If the command doesn't exist, an error message is pushed to the output. If a custom error text is set via the `errorText` prop, it takes precedence over the default one.

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ export default class MyTerminal extends React.Component {
 | commandCallback | Function to execute after each command. See [commandCallback](#commandCallback) for more information. | Function |
 | welcomeMessage | Welcome message(s) to display in terminal. Set to `true` to enable the default welcome message, pass an array to send multiple separate messages, or omit to disable the welcome message entirely. | String/Array/Boolean |
 | promptLabel | Custom prompt label displayed in front of the command input. Omit to enable the default label of `$`. | String |
-| errorText | Custom error text displayed when an unknown command is run. Omit to enable the default message. The placeholder `[command]` in the error string provides the command name that was input | String |
+| errorText | Custom error text displayed when an unknown command is run. Omit to enable the default message. The placeholder `[command]` in the error string provides the command name that was input. | String |
 | background | Terminal background. Accepts any background that [CSS recognises](https://developer.mozilla.org/en-US/docs/Web/CSS/background). | String (Valid CSS) |
 | backgroundSize | The [background-size](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size) CSS property for the terminal background. | String (Valid CSS) |
 | autoFocus | Automatically focus the terminal on page load. | Boolean |

--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ export default class MyTerminal extends React.Component {
 | backgroundSize | The [background-size](https://developer.mozilla.org/en-US/docs/Web/CSS/background-size) CSS property for the terminal background. | String (Valid CSS) |
 | autoFocus | Automatically focus the terminal on page load. | Boolean |
 | dangerMode | Parse command responses as HTML. **Warning:** This may open your application to abuse. It is recommended that you employ anti-XSS methods to validate command responses when using this option. | Boolean |
-| noDefaults | Do not register default commands. **Warning:** If you enable this, you must manually create all command or otherwise the terminal will be moot. | Boolean |
-| noAutomaticStdout | Disable all automatic output. Useful if you need to rely on [manualPushToStdout()](#static-output). | Boolean |
+| disableOnProcess | Disable terminal input while a command is being processed. | Boolean |
+| noDefaults | Do not register default commands. **Warning:** If you enable this, you must manually create all commands or otherwise the terminal will be moot. | Boolean |
+| noAutomaticStdout | Disable all automatic output. | Boolean |
 | noHistory | Disable command history. | Boolean |
 | noAutoScroll | Disable the behaviour where the terminal scrolls to the bottom after each command. | Boolean |
 | textColor | The colour of the text in the terminal, minus the prompt label and input. | String (Valid CSS) |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ export default class MyTerminal extends React.Component {
 | inputAreaClassName | The CSS class name of the input area (Prompt + input). | String |
 | promptLabelClassName | The CSS class name of the prompt label. | String |
 | inputClassName | The CSS class name of the input element. | String |
+| contentFontFamily | The font family to use for the terminal content container (Stdout + prompt + input) | String (Valid CSS) |
+| inputFontFamily | The font family to use for the input element. | String (Valid CSS) |
 
 ## Method reference
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
 
 A simple, powerful and highly customisable terminal emulator for React.
 
-I developed this project for [JS-RCON](https://github.com/js-rcon/js-rcon-frontend) and decided to publish it for public use, since I felt other options weren't sufficient.
-
-I mean, this kind of thing has to be useful to anyone else than me, right? No? Well, it's a nice idea anyway.
-
 ## Features
 
 - Highly customisable: Add your own background image, change the colour of different terminal elements and more!
@@ -51,7 +47,7 @@ export default class MyTerminal extends React.Component {
 | Prop | Description | Type |
 | ---- | ----------- | ---- |
 | commands | Commands for the terminal. See [Command syntax](#command-syntax) for more information. | Object |
-| commandCallback | Function to execute after each command. See [commandCallback](#commandCallback) for more information. | Function |
+| commandCallback | Function to execute after each command. See [commandCallback](#commandcallback) for more information. | Function |
 | welcomeMessage | Welcome message(s) to display in terminal. Set to `true` to enable the default welcome message, pass an array to send multiple separate messages, or omit to disable the welcome message entirely. | String/Array/Boolean |
 | promptLabel | Custom prompt label displayed in front of the command input. Omit to enable the default label of `$`. | String |
 | errorText | Custom error text displayed when an unknown command is run. Omit to enable the default message. The placeholder `[command]` in the error string provides the command name that was input. | String |
@@ -101,21 +97,6 @@ commandCallback={result => console.log(result)}
 */
 ```
 
-### static manualPushToStdout (message, dangerMode, contentElement, inputElement, inputAreaElement)
-
-This is a static function you can call on an instance of react-console-emulator. It allows you to manually push output to the terminal. This may be useful if you have async code that needs to push output even after the function has returned.
-
-**Warning:** Using this function is not optimal and should be avoided if possible. If used, it is additionally recommended to set the **noAutomaticStdout** property to disable automatic output and command history (The latter of which will not work in this case).
-
-**Parameter reference**
-
-| Parameter | Description | Type |
-| --------- | ----------- | ---- |
-| message | The message to push to the console. Can be HTML if **dangerMode** is set to true. | String |
-| dangerMode | If set, set message content with innerHTML as opposed to innerText. It is highly recommended to XSS-proof the message if this setting is being used. | Boolean |
-| contentElement | The content element to push output to. Uses the first element with the name **react-console-emulator__content** on the page if omitted. | HTMLElement |
-| inputElement | The input element to clear after a command. Uses the first element with the name **react-console-emulator__input** on the page if omitted. | HTMLElement |
-| inputAreaElement | The input area element to re-position after a command. Uses the first element with the name **react-console-emulator__inputArea** on the page if omitted. | HTMLElement |
 
 ## Command syntax
 
@@ -140,3 +121,68 @@ const commands = {
   }
 }
 ```
+
+## Async output
+
+If you terminal deals with HTTP requests or cross-component functionality, you may need to wait for a result before pushing to the output.
+
+**Note:** Doing output this way is a workaround, and ideally your output should be returned by the command function. This method will expose functions to you that you do not normally have access to due to React component encapsulation. Proceed with caution.
+
+To do this, you can use the [React refs API](https://reactjs.org/docs/refs-and-the-dom.html). Below is an example component that uses async pushing.
+
+```jsx
+import React from 'react'
+import Terminal from 'react-console-emulator'
+
+class MyTerminal extends React.Component {
+  constructor (props) {
+    super(props)
+    this.terminal = React.createRef()
+  }
+
+  // Experimental syntax, requires Babel with the transform-class-properties plugin
+  // You may also define commands within render in case you don't have access to class field syntax
+  commands = {
+    wait: {
+      description: 'Waits one second and sends a message.'
+      fn: () => {
+        const terminal = this.terminal.current
+        setTimeout(() => terminal.pushToStdout('Hello after 1 second!'), 1500)
+        return 'Running, please wait...'
+      }
+    }
+  }
+
+  render () {
+    return (
+      <Terminal
+        ref={this.terminal} // Assign ref to the terminal here
+        commands={commands}
+      />
+    )
+  }
+}
+```
+
+The function of the `wait` command hooks into the terminal lifecycle (See [Terminal lifecycle](#terminal-lifecycle) for more on that) and pushes content to the output of the terminal after the command function has already terminated. This way, you can perform tasks elsewhere and push the output to the terminal when you get the result.
+
+The only notable caveat of this method is the breaking of component encapsulation. This is the trade-off for being able to push content on demand.
+
+**Note:** Assigning a ref to the terminal component **exposes all of its functions and properties**. As such, you should take adequate measures against this being abused by end users and treat an exposed terminal with caution in genreral.
+
+### Terminal lifecycle
+
+Per standard, the terminal operates in the following way when a command is entered. You can hook into these processes when the terminal is exposed via the refs API.
+
+- A key event triggers the [handleInput](src/components/Terminal.jsx#L242) function.
+- The [handleInput](src/components/Terminal.jsx#L242) function behaves as follows:
+  - If the up or down arrows were pressed, [scrollHistory](src/components/Terminal.jsx#L200) is called with either `up` or `down` as a parameter, corresponding to the arrow key that was pressed.
+  - If the Enter key was pressed, [processCommand](src/components/Terminal.jsx#L163) is called.
+- Following the Enter path, if automatic stdout isn't disabled via the `noAutomaticStdout` prop, [pushToStdout](src/components/Terminal.jsx#L128) is called for the first time. This echoes the command that was entered into the terminal verbatim to mimic a UNIX terminal.
+  - If history isn't disabled via the `noHistory` prop, the entered command is also stored in the history at this stage.
+- If the input isn't empty, command processing begins.
+  - If the command doesn't exist, an error message is pushed to the output. If a custom error text is set via the `errorText` prop, it takes precedence over the default one.
+  - If the command exists, the command function is executed and the return value of that function is pushed to the terminal (Without storing the return value in history). If the `explicitExec` property on the command object is truthy, the function will explicitly execute a second time after the output being sent.
+- The [clearInput](src/components/Terminal.jsx#L158) function is called.
+- If automatic scrolling isn't disabled via the `noAutoScroll` prop, the terminal will scroll to the bottom of the output.
+- If a command callback function is defined via the `commandCallback` prop, it is called at this stage.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,19 @@
+<img src="https://i.linuswillner.me/ot0GAp8.png" height="250px">
+
 # react-console-emulator
 
-![Demo GIF](https://i.linuswillner.me/7u4Cd2V.gif)
+A simple, powerful and highly customisable Unix terminal emulator for React.
 
 ### [Live demo](https://linuswillner.me/react-console-emulator/)
 
-A simple, powerful and highly customisable terminal emulator for React.
-
 ## Features
 
-- Highly customisable: Add your own background image, change the colour of different terminal elements and more!
-- Extensively emulates a Unix terminal with dutiful accuracy
+- Highly customisable: Add custom responses, restyle and tweak the terminal to your liking and much more.
+- A Unix terminal in the browser: Accurately emulate a native Unix terminal in the browser with no setup required.
+- Familiar shortcuts: The terminal can keep track of commands and allows the user to recall them at their behest.
 - Easy and powerful command system: Execute code from your own application and send the results to the terminal output.
-- High concurrency: Register multiple terminals on the same page easily and safely without risk of mixing up inputs.
+- Async output support: Push output to the terminal at any time, even after a command response has been emitted.
+- Unlimited concurrency: Register as many terminals as you like with no risk of input confusion.
 
 ## Usage
 
@@ -117,14 +119,14 @@ const commands = {
       // What you return in this function will be output to the terminal
       return `test ${lowerCaseArg1}`
     },
-    explicitExec: true, // If your command outputs nothing to the terminal and you only need the function to be run, enable this
+    explicitExec: true, // If you need to execute your function again after the output has been emitted, enable
   }
 }
 ```
 
 ## Async output
 
-If you terminal deals with HTTP requests or cross-component functionality, you may need to wait for a result before pushing to the output.
+If you terminal deals with HTTP requests or cross-component functionality, you may need to wait for a result before pushing to the output without relying on the function return time.
 
 **Note:** Doing output this way is a workaround, and ideally your output should be returned by the command function. This method will expose functions to you that you do not normally have access to due to React component encapsulation. Proceed with caution.
 
@@ -186,3 +188,8 @@ Per standard, the terminal operates in the following way when a command is enter
 - The [clearInput](src/components/Terminal.jsx#L158) function is called.
 - If automatic scrolling isn't disabled via the `noAutoScroll` prop, the terminal will scroll to the bottom of the output.
 - If a command callback function is defined via the `commandCallback` prop, it is called at this stage.
+
+## License
+
+MIT © Linus Willner and Curtis Fowler.  
+"React" and any associated logos are trademarks of Facebook, Inc.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1070,15 +1070,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
           "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^1.0.0"
           }
@@ -2469,7 +2467,7 @@
     },
     "cacache": {
       "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/cacache/-/cacache-11.2.0.tgz",
       "integrity": "sha512-IFWl6lfK6wSeYCHUXh+N1lY72UDrpyrYQJNIVQf48paDuWbv5RbAtJYf/4gUQFObTCHZwdZ5sI8Iw7nqwP6nlQ==",
       "dev": true,
       "requires": {
@@ -5245,8 +5243,7 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5396,14 +5393,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5422,7 +5417,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5515,7 +5509,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5601,8 +5594,7 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5700,14 +5692,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6069,7 +6059,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
@@ -7973,7 +7963,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },
@@ -8641,7 +8631,7 @@
           "dependencies": {
             "kind-of": {
               "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
+              "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
               "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
               "dev": true,
               "requires": {
@@ -9942,7 +9932,7 @@
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         },
@@ -10771,6 +10761,7 @@
       "version": "16.6.3",
       "resolved": "https://registry.npmjs.org/react/-/react-16.6.3.tgz",
       "integrity": "sha512-zCvmH2vbEolgKxtqXL2wmGCUxUyNheYn/C+PD1YAjfxHC54+MhdruyhO7QieQrYsYeTxrn93PM2y0jRH1zEExw==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -10782,6 +10773,7 @@
           "version": "0.11.2",
           "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
           "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
+          "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
@@ -10793,6 +10785,7 @@
       "version": "16.6.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.6.3.tgz",
       "integrity": "sha512-8ugJWRCWLGXy+7PmNh8WJz3g1TaTUt1XyoIcFN+x0Zbkoz+KKdUyx1AQLYJdbFXjuF41Nmjn5+j//rxvhFjgSQ==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -10804,6 +10797,7 @@
           "version": "0.11.2",
           "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.11.2.tgz",
           "integrity": "sha512-+WCP3s3wOaW4S7C1tl3TEXp4l9lJn0ZK8G3W3WKRWmw77Z2cIFUW2MiNTMHn5sCjxN+t7N43HAOOgMjyAg5hlg==",
+          "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
@@ -13568,7 +13562,7 @@
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -14623,7 +14617,7 @@
     },
     "yargs": {
       "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
       "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-console-emulator",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5192,8 +5192,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5214,14 +5213,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5236,14 +5233,12 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -5365,8 +5360,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5378,7 +5372,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5393,7 +5386,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5505,8 +5497,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5639,7 +5630,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5659,7 +5649,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9165,7 +9154,7 @@
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
           "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "node-sass": "^4.10.0",
     "optimize-css-assets-webpack-plugin": "^5.0.1",
     "puppeteer": "^1.10.0",
+    "react": "^16.6.3",
+    "react-dom": "^16.6.3",
     "react-hot-loader": "^4.3.12",
     "sass-loader": "^7.1.0",
     "skip-if": "^1.1.1",
@@ -78,8 +80,6 @@
   },
   "dependencies": {
     "prop-types": "^15.6.2",
-    "react": "^16.6.3",
-    "react-dom": "^16.6.3",
     "react-inner-html": "^1.0.1",
     "stringify-object": "^3.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -82,5 +82,9 @@
     "react-dom": "^16.6.3",
     "react-inner-html": "^1.0.1",
     "stringify-object": "^3.3.0"
+  },
+  "peerDependencies": {
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-console-emulator",
-  "version": "1.7.3",
+  "version": "2.0.0",
   "description": "A simple terminal emulator component for React. ",
   "main": "lib/components/Terminal.js",
   "files": [

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,6 +16,11 @@ class DemoTile extends React.Component {
 }
 
 export default class App extends React.Component {
+  constructor (props) {
+    super(props)
+    this.terminal = React.createRef()
+  }
+
   commands = {
     echo: {
       description: 'Echo a passed string.',
@@ -38,24 +43,12 @@ export default class App extends React.Component {
   }
 
   manualPushCommands = {
-    safe: {
-      fn: function () {
-        const content = document.getElementsByName('react-console-emulator__content')[4]
-        const input = document.getElementsByName('react-console-emulator__inputArea')[4]
-
-        // By using Function.arguments, you can show correct commands in the terminal
-        Terminal.manualPushToStdout(`$ safe${arguments ? ` ${Array.from(arguments).join(' ')}` : ''}`, content, input)
-        Terminal.manualPushToStdout('This message was manually pushed to the terminal.', content, input)
-      }
-    },
-    dangerous: {
-      fn: function () {
-        const content = document.getElementsByName('react-console-emulator__content')[4]
-        const input = document.getElementsByName('react-console-emulator__inputArea')[4]
-
-        // By using Function.arguments, you can show correct commands in the terminal
-        Terminal.manualPushToStdout(`$ dangerous${arguments ? ` ${Array.from(arguments).join(' ')}` : ''}`, content, input)
-        Terminal.manualPushToStdout('<div style="color: red;">This message was manually pushed the terminal with danger mode enabled.</div>', content, input, true)
+    wait: {
+      description: 'Waits 1000 ms and then pushes content to the output like any command.',
+      fn: () => {
+        const terminal = this.terminal.current
+        setTimeout(() => terminal.pushToStdout('Tada! 1000 ms passed!'), 1000)
+        return 'Running, please wait...'
       }
     }
   }
@@ -110,11 +103,9 @@ export default class App extends React.Component {
         <div className={'demo'}>
           <DemoTile>
             <Terminal
+              ref={this.terminal}
               commands={this.manualPushCommands}
-              welcomeMessage={'This terminal has no automatic output and only uses manual pushing. Try the "safe" and "dangerous" commands.'}
-              noDefaults={true}
-              noAutomaticStdout={true} // Disables history as well
-              errorText={'I couldn\'t find a command called [command]!'}
+              welcomeMessage={'This terminal uses manual pushing, yet works as any normal terminal. Check the help command for more information.'}
             />
           </DemoTile>
           <DemoTile>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,6 +21,10 @@ export default class App extends React.Component {
     this.terminal = React.createRef()
   }
 
+  globalProps = {
+    contentFontFamily: `'Inconsolata', monospace`
+  }
+
   commands = {
     echo: {
       description: 'Echo a passed string.',
@@ -59,12 +63,14 @@ export default class App extends React.Component {
         <div className={'demo'}>
           <DemoTile>
             <Terminal
+              {...this.globalProps}
               commands={this.commands}
               dangerMode={true}
             />
           </DemoTile>
           <DemoTile>
             <Terminal
+              {...this.globalProps}
               commands={this.commands}
               welcomeMessage={true}
             />
@@ -73,6 +79,7 @@ export default class App extends React.Component {
         <div className={'demo'}>
           <DemoTile>
             <Terminal
+              {...this.globalProps}
               commands={this.newDefaultCommands}
               welcomeMessage={[
                 'This terminal is automatically focused on page load and has no default commands. It also has a custom error message.',
@@ -86,6 +93,7 @@ export default class App extends React.Component {
           </DemoTile>
           <DemoTile>
             <Terminal
+              {...this.globalProps}
               commands={this.commands}
               welcomeMessage={[
                 'The terminal is extensively customisable.',
@@ -103,6 +111,7 @@ export default class App extends React.Component {
         <div className={'demo'}>
           <DemoTile>
             <Terminal
+              {...this.globalProps}
               ref={this.terminal}
               commands={this.manualPushCommands}
               welcomeMessage={'This terminal uses manual pushing, yet works as any normal terminal. Check the help command for more information.'}
@@ -110,6 +119,7 @@ export default class App extends React.Component {
           </DemoTile>
           <DemoTile>
             <Terminal
+              {...this.globalProps}
               commands={this.commands}
               welcomeMessage={[
                 'The terminal keeps track of your commands (Unless disabled) and allows you to recall them.',

--- a/src/components/Terminal.jsx
+++ b/src/components/Terminal.jsx
@@ -279,7 +279,8 @@ export default class Terminal extends React.Component {
       },
       content: {
         ...sourceStyles.content,
-        color: this.props.textColor || '#FFFFFF'
+        color: this.props.textColor || '#FFFFFF',
+        fontFamily: this.props.contentFontFamily || 'monospace'
       },
       inputArea: {
         ...sourceStyles.inputArea
@@ -290,7 +291,8 @@ export default class Terminal extends React.Component {
       },
       input: {
         ...sourceStyles.input,
-        color: this.props.promptTextColor || '#F0BF81'
+        color: this.props.promptTextColor || '#F0BF81',
+        fontFamily: this.props.inputFontFamily || 'monospace'
       }
     }
 

--- a/src/components/Terminal.jsx
+++ b/src/components/Terminal.jsx
@@ -33,7 +33,6 @@ export default class Terminal extends React.Component {
     ...types
   }
 
-  // TODO: Replace with ref-based component function
   /**
    * Manually push to the stdout of a terminal. Use with caution.
    * @param {String} message The message to output to the terminal. If not using safe mode, make sure to XSS-proof this.
@@ -43,6 +42,8 @@ export default class Terminal extends React.Component {
    * @param {HTMLElement} inputAreaElement The input area element of the terminal you want to push output to. Uses first found element if omitted.
    */
   static manualPushToStdout (message, dangerMode, contentElement, inputElement, inputAreaElement) {
+    console.warn('DeprecationWarning: Terminal.manualPushToStdout() is deprecated and will be removed in a future release. For more information, see https://github.com/js-rcon/react-console-emulator/blob/master/LEGACY.md')
+
     const content = contentElement || document.getElementsByName('react-console-emulator__content')[0]
     const input = inputElement || document.getElementsByName('react-console-emulator__input')[0]
     const inputArea = inputAreaElement || document.getElementsByName('react-console-emulator__inputArea')[0]

--- a/src/components/Terminal.jsx
+++ b/src/components/Terminal.jsx
@@ -33,6 +33,7 @@ export default class Terminal extends React.Component {
     ...types
   }
 
+  // TODO: Replace with ref-based component function
   /**
    * Manually push to the stdout of a terminal. Use with caution.
    * @param {String} message The message to output to the terminal. If not using safe mode, make sure to XSS-proof this.
@@ -194,6 +195,7 @@ export default class Terminal extends React.Component {
     if (this.props.commandCallback) this.props.commandCallback(commandResult)
   }
 
+  // TODO: Fix wonky scrolling
   scrollHistory (direction) {
     const history = cleanArray(this.state.history).reverse() // Clean empty items and reverse order to ease position tracking
     const position = this.state.historyPosition

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,14 +1,3 @@
-function randstr () {
-  const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-  let str = ''
-
-  for (let i = 0; i < 15; i++) {
-    str += chars.charAt(~~(Math.random() * chars.length))
-  }
-
-  return str
-}
-
 /**
  * Workaround to clean an array from 'ghost items'.
  * @param {Array} dirtyArray
@@ -18,15 +7,4 @@ function cleanArray (dirtyArray) {
   return newArray.filter(i => i !== undefined)
 }
 
-/**
- * Foolproofing function for cases where there are other elements with the same name.
- * @param {HTMLCollection} elements
- * @param {Function} filterCondition
- */
-function filterNode (elements, filterCondition) {
-  // Foolproofing in case there are other elements with the same name
-  if (elements.length > 1) return Array.from(elements).filter(filterCondition)[0]
-  else return elements[0]
-}
-
-export { randstr, cleanArray, filterNode }
+export { cleanArray }

--- a/src/utils/sourceStyles.js
+++ b/src/utils/sourceStyles.js
@@ -11,7 +11,6 @@ export const sourceStyles = {
   content: {
     padding: '20px',
     height: '100%',
-    fontFamily: `'Inconsolata', monospace`,
     fontSize: '15px'
   },
   inputArea: {
@@ -29,7 +28,6 @@ export const sourceStyles = {
     width: '100%',
     height: '22px',
     background: 'transparent',
-    fontFamily: `'Inconsolata', monospace`,
     fontSize: '15px'
   }
 }

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -13,6 +13,7 @@ export const types = {
   inputClassName: PropTypes.string,
   autoFocus: PropTypes.bool,
   dangerMode: PropTypes.bool,
+  disableOnProcess: PropTypes.bool,
   noDefaults: PropTypes.bool,
   noAutomaticStdout: PropTypes.bool,
   noHistory: PropTypes.bool,

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -11,6 +11,8 @@ export const types = {
   inputAreaClassName: PropTypes.string,
   promptLabelClassName: PropTypes.string,
   inputClassName: PropTypes.string,
+  contentFontFamily: PropTypes.string,
+  inputFontFamily: PropTypes.string,
   autoFocus: PropTypes.bool,
   dangerMode: PropTypes.bool,
   disableOnProcess: PropTypes.bool,


### PR DESCRIPTION
Version 2.0.0 brings several major changes to react-console-emulator. The main changes are summarised below.

Closes #37.

- Public-facing changes
  - Added new system for async output based on the React ref API, which will gradually replace the old `manualPushToStdout()` API
  - Added first stage of deprecation to `manualPushToStdout()` (Emission of deprecation warning on use)
  - Moved manual pushing documentation to legacy document along with information about the deprecation
  - Fixed a multitude of bugs related to terminal history scrolling
  - Overhauled README styling and content
  - Added the ability to disable input during command processing
  - Added custom font family support for terminal content and input
  - Added `contentFontFamily`, `inputFontFamily` and `disableOnProcess` props

- Internal changes
  - Migrated instance tracking from unreliable and low-entropy random string system to refs
  - Added `react^16.3.0` and `react-dom^16.3.0` as peerDependencies to ensure support for the `React.createRef()` API
  - Moved `react` and `react-dom` to devDependencies
  - Removed obsolete helper functions
